### PR TITLE
fix: add main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     },
     "./package.json": "./package.json"
   },
+  "main": "./lib/module/index.js",
+  "types": "./lib/typescript/src/index.d.ts",
   "files": [
     "src",
     "lib",


### PR DESCRIPTION
Metamask mobile app is using older version of RN + Metro with disabled exports field support.