### PR TITLE
Fix: treat keccak256 string input as utf8 not hex

### DIFF
--- a/cpp/HybridNativeUtils.cpp
+++ b/cpp/HybridNativeUtils.cpp
@@ -133,18 +133,6 @@ static std::shared_ptr<ArrayBuffer> keccak256Hash(const uint8_t* dataBytes, size
   return result;
 }
 
-std::shared_ptr<ArrayBuffer> HybridNativeUtils::keccak256(const std::string& data) {
-  validateHexString(data);
-  
-  size_t dataLen = data.length() / 2;
-  
-  auto dataBuffer = ArrayBuffer::allocate(dataLen);
-  uint8_t* dataBytes = static_cast<uint8_t*>(dataBuffer->data());
-  
-  hexToBytes(data, dataBytes, dataLen);
-  
-  return keccak256FromBytes(dataBuffer);
-}
 std::shared_ptr<ArrayBuffer> HybridNativeUtils::keccak256FromBytes(const std::shared_ptr<ArrayBuffer>& data) {
   // Get the data bytes
   const uint8_t* dataBytes = static_cast<const uint8_t*>(data->data());

--- a/cpp/HybridNativeUtils.hpp
+++ b/cpp/HybridNativeUtils.hpp
@@ -14,7 +14,6 @@ public:
   std::shared_ptr<ArrayBuffer> toPublicKeyFromBytes(const std::shared_ptr<ArrayBuffer>& privateKey, bool isCompressed) override;
   std::shared_ptr<ArrayBuffer> getPublicKeyEd25519(const std::string& privateKey) override;
   std::shared_ptr<ArrayBuffer> getPublicKeyEd25519FromBytes(const std::shared_ptr<ArrayBuffer>& privateKey) override;
-  std::shared_ptr<ArrayBuffer> keccak256(const std::string& data) override;
   std::shared_ptr<ArrayBuffer> keccak256FromBytes(const std::shared_ptr<ArrayBuffer>& data) override;
   std::shared_ptr<ArrayBuffer> pubToAddress(const std::shared_ptr<ArrayBuffer>& pubKey, bool sanitize = false) override;
   std::shared_ptr<ArrayBuffer> hmacSha512(const std::shared_ptr<ArrayBuffer>& key, const std::shared_ptr<ArrayBuffer>& data) override;

--- a/src/NativeUtils.nitro.ts
+++ b/src/NativeUtils.nitro.ts
@@ -10,7 +10,6 @@ export interface NativeUtils
   ): ArrayBuffer;
   getPublicKeyEd25519(privateKey: string): ArrayBuffer;
   getPublicKeyEd25519FromBytes(privateKey: ArrayBuffer): ArrayBuffer;
-  keccak256(data: string): ArrayBuffer;
   keccak256FromBytes(data: ArrayBuffer): ArrayBuffer;
   pubToAddress(pubKey: ArrayBuffer, sanitize: boolean): ArrayBuffer;
   hmacSha512(key: ArrayBuffer, data: ArrayBuffer): ArrayBuffer;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -66,9 +66,10 @@ export function getPublicKey(
 
 /**
  * Compute Keccak-256 hash using native implementation.
+ * 100% compatible with @noble/hashes keccak_256 API.
  * Accepts multiple input types for maximum flexibility.
  *
- * @param data - The data to hash as string (hex), number[], ArrayBuffer, or Uint8Array
+ * @param data - The data to hash as string (UTF-8), number[], ArrayBuffer, or Uint8Array
  * @returns Uint8Array containing the 32-byte Keccak-256 hash
  */
 export function keccak256(
@@ -77,8 +78,11 @@ export function keccak256(
   let result: ArrayBuffer;
 
   if (typeof data === 'string') {
-    // Assume hex string, use the string version (C++ will handle hex validation)
-    result = NativeUtilsHybridObject.keccak256(data);
+    // Match noble's behavior: treat string as UTF-8 text, not hex
+    const encoder = new TextEncoder();
+    const bytes = encoder.encode(data);
+    const buffer = uint8ArrayToArrayBuffer(bytes);
+    result = NativeUtilsHybridObject.keccak256FromBytes(buffer);
   } else if (Array.isArray(data)) {
     // Convert number array to Uint8Array, then to ArrayBuffer
     const bytes = numberArrayToUint8Array(data);
@@ -93,7 +97,7 @@ export function keccak256(
     result = NativeUtilsHybridObject.keccak256FromBytes(buffer);
   } else {
     throw new Error(
-      'Data must be a hex string, number[], ArrayBuffer, or Uint8Array',
+      'Data must be a string, number[], ArrayBuffer, or Uint8Array',
     );
   }
 


### PR DESCRIPTION
I did mistake and assumed that hex string input should be hex encoded bytes, but @noble which we are want to polyfill treats hex string as plain UTF8 string, not hex encoded bytes.

Tests in separate PR: https://github.com/MetaMask/native-utils/pull/33